### PR TITLE
Localization: Use UTF8 for german umlauts

### DIFF
--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -5,11 +5,11 @@ $labels['activate'] = 'Aktivieren';
 $labels['twofactor_gauthenticator'] = 'Zwei-Faktor-Authentifizierung';
 $labels['code'] = 'Google-Authenticator-Code';
 
-$labels['two_step_verification_form'] = 'Zwei-Faktor-Best&auml;tigungscode';
+$labels['two_step_verification_form'] = 'Zwei-Faktor-Bestätigungscode';
 
 $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR-Code';
-$labels['msg_infor'] = 'Sie k&ouml;nnen mit jeder TOTP kompatiblen App wie z.B. <a href="https://github.com/google/google-authenticator" target="_blank">Google-Authenticator</a> ein Secret erstellen und dieses verwenden.';
+$labels['msg_infor'] = 'Sie können mit jeder TOTP kompatiblen App wie z.B. <a href="https://github.com/google/google-authenticator" target="_blank">Google-Authenticator</a> ein Secret erstellen und dieses verwenden.';
 
 $labels['show_secret'] = 'Zeige Secret';
 $labels['hide_secret'] = 'Verstecke Secret';
@@ -25,15 +25,15 @@ $labels['hide_recovery_codes'] = 'Verstecke Wiederherstellungscodes';
 $labels['setup_all_fields'] = 'Erstelle fehlende Werte (Speichern klicken, um Ihre Einstellungen zu sichern)';
 
 $labels['enrollment_dialog_title'] = 'Zwei-Faktor-Authentifizierung';
-$labels['enrollment_dialog_msg'] = '<strong>Best&auml;tigungscodes f&uuml;r Zwei-Faktor-Authentifizierung</strong> werden aus Sicherheitsgr&uuml;nden ben&ouml;tigt, bitte konfigurieren!';
+$labels['enrollment_dialog_msg'] = '<strong>Bestätigungscodes für Zwei-Faktor-Authentifizierung</strong> werden aus Sicherheitsgründen benötigt, bitte konfigurieren!';
 
-$labels['check_code'] = '&Uuml;berpr&uuml;fe Code';
+$labels['check_code'] = 'Überprüfe Code';
 $labels['code_ok'] = 'Code OK';
 $labels['code_ko'] = 'Falscher Code';
 
-$labels['dont_ask_me_30days'] = 'Nicht erneut nach dem Code fragen f&uuml;r die n&auml;chsten 30 Tage';
+$labels['dont_ask_me_30days'] = 'Nicht erneut nach dem Code fragen für die nächsten 30 Tage';
 
-$labels['check_code_to_activate'] = 'Um zu speichern, muss mindestens 1 Code zuvor gepr&uuml;pft werden';
+$labels['check_code_to_activate'] = 'Um zu speichern, muss mindestens 1 Code zuvor geprüft werden';
 
 // Messages used for the different portions of the plugin
 $messages = array();


### PR DESCRIPTION
... those were written as HTML entities, which does not work for button labels.